### PR TITLE
Expose timestamps to the app

### DIFF
--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -125,6 +125,24 @@ impl<PdC: PdClient> Transaction<PdC> {
             .await
     }
 
+    pub fn get_read_timestamp(&self) -> Timestamp {
+        self.timestamp.clone()
+    }
+
+    pub async fn get_current_timestamp(&mut self) -> Result<Timestamp> {
+        self.check_allow_operation().await?;
+        let rpc = self.rpc.clone();
+
+        // Convert to the timestamp to bytes.
+        let r = rpc.get_timestamp().await;
+        match r {
+            Ok(ts) => {
+                Ok(ts)
+            },
+            Err(e) => Err(e),
+        }
+    }
+
     /// Create a `get for update` request.
     ///
     /// The request reads and "locks" a key. It is similar to `SELECT ... FOR


### PR DESCRIPTION
These are the minimal changes that turned out to be necessary to the TiKV Rust client for our first implementation
of change feeds(might be renamed to CDC or whatever makes more sense- we don't have a roadmap item on our site yet!).

We will use these two functions for our unsound and sound variants of "change timestamps."
`get_read_timestamp` will be used for the unsound ones without making it "serializable."
`get_current_timestamp` will be used for the sound ones by wrapping it within the TiKV transactions to provide a virtual,
monotonic commit-timestamp-like timestamp.

We do know that neither of those is going to provide the ideal guarantee we might want for CDC, but we'll use it for
more performance-sensitive use cases and maybe as the baseline for benchmarking other implementations of "timestamps."

Hey @tobiemh, can we have a branch in our repo, named like `0.1.x` or `0.1` that initially points to https://github.com/tikv/client-rust/tree/0.1.0, and merge this into the branch?

`surrealdb` currently relies on client-rust v0.1.0 and the `master` branch of this repo is very much ahead of v0.1.0.
I'd like to keep the changes minimal for now by separating introduction of these two functions from upgrading to a more recent version of client-rust.