### PR TITLE
0.1.0: Expose get_timestamp

### DIFF
--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -125,6 +125,24 @@ impl<PdC: PdClient> Transaction<PdC> {
             .await
     }
 
+    pub fn get_read_timestamp(&self) -> Timestamp {
+        self.timestamp.clone()
+    }
+
+    pub async fn get_current_timestamp(&mut self) -> Result<Timestamp> {
+        self.check_allow_operation().await?;
+        let rpc = self.rpc.clone();
+
+        // Convert to the timestamp to bytes.
+        let r = rpc.get_timestamp().await;
+        match r {
+            Ok(ts) => {
+                Ok(ts)
+            },
+            Err(e) => Err(e),
+        }
+    }
+
     /// Create a `get for update` request.
     ///
     /// The request reads and "locks" a key. It is similar to `SELECT ... FOR


### PR DESCRIPTION
This is a repeat of #1 against our 0.1.0 branch.
The plan is to cut 0.1.0-surreal.1 from the 0.1.0-surreal.x branch that includes this change.
We'll also repeat this for every minor and patch version TiKV will make.