### PR TITLE
[deps] Disabled prometheus/push so this crate don't need native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb-tikv-client"
-version = "0.2.0-surreal.1"
+version = "0.2.0-surreal.2"
 keywords = ["TiKV", "KV", "distributed-systems"]
 license = "Apache-2.0"
 authors = ["The TiKV Project Authors"]
@@ -33,7 +33,7 @@ futures = { version = "0.3" }
 lazy_static = "1"
 log = "0.4"
 pin-project = "1"
-prometheus = { version = "0.13", features = ["push"], default-features = false }
+prometheus = { version = "0.13", default-features = false }
 prost = "0.11"
 rand = "0.8"
 regex = "1"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ INTEGRATION_TEST_ARGS := --features "integration-tests"
 default: check
 
 generate:
-	cargo run -p tikv-client-proto-build
+	cargo run -p surrealdb-tikv-client-proto-build
 
 check: generate
 	cargo check --all --all-targets --features "${ALL_FEATURES}"

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -156,9 +156,7 @@ impl<PdC: PdClient> Transaction<PdC> {
         // Convert to the timestamp to bytes.
         let r = rpc.get_timestamp().await;
         match r {
-            Ok(ts) => {
-                Ok(ts)
-            },
+            Ok(ts) => Ok(ts),
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
The `push` feature for the `prometheus` crate depends on `reqwest`, which depends on `native-tls` by default.

Since we are not using the `prometheus/push` feature for now, let's disable it and come back to it once the funcionality becomes necessary.

This is necessary for surrealdb to not depend on `native-tls` and rely on `rustls` completely